### PR TITLE
Hotfix: Links to constants

### DIFF
--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -105,9 +105,9 @@
       <table border='0' cellpadding='5'>
         <% context.each_constant do |const| %>
           <tr valign='top'>
-            <td class="attr-name"><%= h const.name %></td>
+            <td class="attr-name"><a name="<%= h const.name %>"><%= h const.name %></a></td>
             <td>=</td>
-            <td class="attr-value"><%= h const.value %></td>
+            <td class="attr-value"><pre><%= h const.value %></pre></td>
           </tr>
           <% if const.comment %>
             <tr valign='top'>


### PR DESCRIPTION
- Fix links to constants by including the named anchor
- Preformatted constant values for correct multiline output
