### PR TITLE
Upstream updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: ruby
 cache: bundler
 before_install:
+  - gem update --system
   - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - 2.2.9
-  - 2.3.6
-  - 2.4.2
-  - 2.5.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
   - jruby-head
 matrix:
@@ -17,10 +18,10 @@ matrix:
     - env: rdoc=master
     - rvm: jruby-head
   include:
-    - { rvm: 2.2.9, env: rdoc=master }
-    - { rvm: 2.3.6, env: rdoc=master }
-    - { rvm: 2.4.2, env: rdoc=master }
-    - { rvm: 2.5.0, env: rdoc=master }
+    - { rvm: 2.2.10, env: rdoc=master }
+    - { rvm: 2.3.7, env: rdoc=master }
+    - { rvm: 2.4.4, env: rdoc=master }
+    - { rvm: 2.5.1, env: rdoc=master }
     - { rvm: ruby-head, env: rdoc=master }
     - { rvm: jruby-head, env: rdoc=master }
 notifications:

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ require 'sdoc' # and use your RDoc task the same way you used it before
 require 'rdoc/task' # ensure this file is also required in order to use `RDoc::Task`
 
 RDoc::Task.new do |rdoc|
-  rdoc.rdoc_dir = 'doc/rdoc' # name of output directory
-  rdoc.generator = 'sdoc' # explictly set the sdoc generator
-  rdoc.template = 'rails' # template used on api.rubyonrails.org
+  rdoc.rdoc_dir = 'doc/rdoc'      # name of output directory
+  rdoc.options << '--format=sdoc' # explictly set the sdoc generator
+  rdoc.template = 'rails'         # template used on api.rubyonrails.org
 end
 ```
 

--- a/bin/sdoc
+++ b/bin/sdoc
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -KU
+#!/usr/bin/env ruby
 require 'sdoc'
 
 begin

--- a/bin/sdoc-merge
+++ b/bin/sdoc-merge
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -KU
+#!/usr/bin/env ruby
 require File.dirname(__FILE__) + '/../lib/sdoc' # add extensions
 require 'sdoc/merge'
 

--- a/lib/rdoc/discover.rb
+++ b/lib/rdoc/discover.rb
@@ -1,5 +1,5 @@
 begin
-  gem 'rdoc', '~> 5.0'
+  gem 'rdoc', '>= 5.0'
   require File.join(File.dirname(__FILE__), '/../sdoc')
 rescue Gem::LoadError
 end

--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -30,10 +30,16 @@
     <!-- Namespace -->
     <div class="sectiontitle">Namespace</div>
     <ul>
-<%   (context.modules.sort + context.classes.sort).each do |mod| %>
+<%   (context.modules.sort + context.classes.sort).each do |mod|
+       mod_path = mod.path rescue nil
+%>
         <li>
             <span class="type"><%= mod.type.upcase %></span>
-            <a href="<%= context.aref_to mod.path %>"><%= mod.full_name %></a>
+<%          if mod_path.nil? %>
+              <%= mod.full_name %>
+<%          else %>
+              <a href="<%= context.aref_to mod_path %>"><%= mod.full_name %></a>
+<%          end %>
         </li>
 <%   end %>
     </ul>

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'sdoc/github'
 require 'sdoc/templatable'
 require 'sdoc/helpers'
+require 'sdoc/version'
 require 'rdoc'
 
 class RDoc::ClassModule
@@ -59,6 +60,10 @@ class RDoc::Generator::SDoc
     end
     opt.separator nil
 
+    opt.on("--version", "-v", "Output current version") do
+      puts SDoc::VERSION
+      exit
+    end
   end
 
   def initialize(store, options)

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -37,4 +37,12 @@ describe RDoc::Generator::SDoc do
     err.wont_match(/^invalid options/)
     @options.github.must_equal true
   end
+
+  it "should display SDoc version on -v or --version" do
+    out_full  = `./bin/sdoc --version`
+    out_short = `./bin/sdoc -v`
+
+    out_short.strip.must_equal SDoc::VERSION
+    out_full.strip.must_equal SDoc::VERSION
+  end
 end


### PR DESCRIPTION
Pulls in upstream changes for maintenance, plus one bug workaround.

Under RDoc 6.0.x, sometimes the call to `path` for a module would fail with an attempt to call a method on `nil`. This only occurs with relatively complex documentation collections (e.g. a Hoodoo service); I haven't tracked down the exact conditions so have not yet filed a bug report as replicability is low. RDoc 5 does not suffer this problem.

This PR includes a fix which just rescues from this and leaves a `nil` path value internally. In generated documentation, the `files` hierarchy is seen to be affected; a module or class listed under `Namespaces` for a particular file may be shown by name only, without a link. That's better than outright failing to generate any documentation!